### PR TITLE
fix: update kms key policy, sns policy, stackset instance creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ No modules.
 |------|------|
 | [aws_cloudformation_stack.lacework_stack](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack) | resource |
 | [aws_cloudformation_stack_set.lacework_stackset](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
+| [aws_cloudformation_stack_set_instance.lacework_stackset_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
 | [aws_iam_role.lacework_copy_zip_files_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.lacework_setup_function_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_kms_key.lacework_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
@@ -56,6 +57,7 @@ No modules.
 | [aws_iam_policy_document.lacework_setup_function_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sns_topic_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ No modules.
 | <a name="input_lacework_secret_key"></a> [lacework\_secret\_key](#input\_lacework\_secret\_key) | n/a | `string` | n/a | yes |
 | <a name="input_lacework_subaccount"></a> [lacework\_subaccount](#input\_lacework\_subaccount) | If Lacework Organizations is enabled, enter the sub-account.  Leave blank if Lacework Organizations is not enabled. | `string` | `""` | no |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | AWS Organization ID where these resources are being deployed into | `string` | n/a | yes |
-| <a name="input_organization_unit"></a> [organization\_unit](#input\_organization\_unit) | Organizational Unit ID that the stackset will be deployed into | `string` | n/a | yes |
+| <a name="input_organization_unit"></a> [organization\_unit](#input\_organization\_unit) | Organizational Unit ID that the stackset will be deployed into | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -369,7 +369,7 @@ resource "aws_cloudformation_stack_set" "lacework_stackset" {
 data "aws_region" "current" {}
 resource "aws_cloudformation_stack_set_instance" "lacework_stackset_instances" {
   deployment_targets {
-    organizational_unit_ids = [var.organization_unit]
+    organizational_unit_ids = var.organization_unit
   }
 
   region         = data.aws_region.current.name

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "organization_id" {
 }
 
 variable "organization_unit" {
-  type        = string
+  type        = list(string)
   description = "Organizational Unit ID that the stackset will be deployed into"
 }
 


### PR DESCRIPTION
Additional updates required for member accounts to use SNS topic, add dependencies so stack can be torn down, and to create stackset instances so deployment occurs.