### PR TITLE
fix: enable parallel stackset operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.11.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.55.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.11.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.55.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.35.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.11.0 |
 
 ## Modules
 
@@ -77,6 +77,10 @@ No modules.
 | <a name="input_lacework_subaccount"></a> [lacework\_subaccount](#input\_lacework\_subaccount) | If Lacework Organizations is enabled, enter the sub-account.  Leave blank if Lacework Organizations is not enabled. | `string` | `""` | no |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | AWS Organization ID where these resources are being deployed into | `string` | n/a | yes |
 | <a name="input_organization_unit"></a> [organization\_unit](#input\_organization\_unit) | Organizational Unit ID that the stackset will be deployed into | `list(string)` | n/a | yes |
+| <a name="input_stackset_failure_tolerance_count"></a> [stackset\_failure\_tolerance\_count](#input\_stackset\_failure\_tolerance\_count) | The maxiumum number of failed AWS account integrations to tolerate | `number` | `5` | no |
+| <a name="input_stackset_managed_execution"></a> [stackset\_managed\_execution](#input\_stackset\_managed\_execution) | Allow StackSets to perform non-conflicting operations concurrently and queues conflicting operations. | `bool` | `true` | no |
+| <a name="input_stackset_max_concurrent_count"></a> [stackset\_max\_concurrent\_count](#input\_stackset\_max\_concurrent\_count) | The maximum number of AWS accounts to deploy to concurrently | `number` | `50` | no |
+| <a name="input_stackset_region_concurrency_type"></a> [stackset\_region\_concurrency\_type](#input\_stackset\_region\_concurrency\_type) | Allow stackset instance deployment to run in parallel | `string` | `"PARALLEL"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,16 @@
 locals {
+  # Python3.9 support introduced in version 3.55.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/release/3.x/CHANGELOG.md#3550-august-19-2021
+  python_version = "python3.9"
+
+  # Python3.10 support introduced in version 4.64.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/release/4.x/CHANGELOG.md#4640-april-20-2023
+  # python_version = "python3.10"
+
+  # Python3.11 support introduced in version 5.11.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5110-august--3-2023
+  # python_version = "python3.11"
+
   kms_key_arn   = length(var.kms_key_arn) > 0 ? var.kms_key_arn : aws_kms_key.lacework_kms_key[0].arn
   lambda_zip    = "LaceworkIntegrationSetup1.1.2.zip"
   s3_lambda_key = "${var.cf_s3_prefix}/lambda/${local.lambda_zip}"
@@ -44,9 +56,9 @@ resource "aws_lambda_function" "lacework_copy_zip_files" {
   function_name    = "lacework_copy_zip_files"
   handler          = "index.handler"
   role             = aws_iam_role.lacework_copy_zip_files_role.arn
-  runtime          = "python3.11"
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   timeout          = 240
+  runtime          = local.python_version
 
   tracing_config {
     mode = "Active"
@@ -143,10 +155,10 @@ resource "aws_lambda_function" "lacework_setup_function" {
   function_name = "lacework_setup_function"
   handler       = "lw_integration_lambda_function.handler"
   role          = aws_iam_role.lacework_setup_function_role.arn
-  runtime       = "python3.11"
   s3_bucket     = aws_s3_bucket.lacework_org_lambda.bucket
   s3_key        = local.s3_lambda_key
   timeout       = 900
+  runtime       = local.python_version
 
   tracing_config {
     mode = "Active"

--- a/main.tf
+++ b/main.tf
@@ -326,8 +326,7 @@ resource "aws_cloudformation_stack" "lacework_stack" {
   }
   template_url       = "https://s3.amazonaws.com/${var.cf_s3_bucket}/${var.cf_s3_prefix}/templates/lacework-aws-cfg-member.template.yml"
   timeout_in_minutes = 30
-
-  depends_on = [ // depending on all this ensures the stack can be torn down
+  depends_on = [ // depending on all this ensures the stackinstances can be torn down properly
     aws_s3_bucket.lacework_org_lambda,
     aws_sns_topic.lacework_sns_topic,
     aws_sns_topic_subscription.lacework_sns_subscription,
@@ -353,22 +352,19 @@ resource "aws_cloudformation_stack_set" "lacework_stackset" {
     ignore_changes = [administration_role_arn]
   }
 
-  operation_preferences {
-    failure_tolerance_count   = 20
-    max_concurrent_percentage = 100
-  }
-
   parameters = {
     LaceworkAccount    = var.lacework_account
     MainAccountSNS     = aws_sns_topic.lacework_sns_topic.arn
     ResourceNamePrefix = var.cf_resource_prefix
   }
 
+  managed_execution {
+    active = var.stackset_managed_execution
+  }
+
   permission_model = "SERVICE_MANAGED"
   template_url     = "https://s3.amazonaws.com/${var.cf_s3_bucket}/${var.cf_s3_prefix}/templates/lacework-aws-cfg-member.template.yml"
-
-
-  depends_on = [ // depending on all this ensures the stackinstances can be torn down
+  depends_on = [ // depending on all this ensures the stackinstances can be torn down properly
     aws_s3_bucket.lacework_org_lambda,
     aws_sns_topic.lacework_sns_topic,
     aws_sns_topic_subscription.lacework_sns_subscription,
@@ -386,6 +382,21 @@ resource "aws_cloudformation_stack_set_instance" "lacework_stackset_instances" {
     organizational_unit_ids = var.organization_unit
   }
 
+  operation_preferences {
+    failure_tolerance_count = var.stackset_failure_tolerance_count
+    max_concurrent_count    = var.stackset_max_concurrent_count
+    region_concurrency_type = var.stackset_region_concurrency_type
+  }
+
   region         = data.aws_region.current.name
   stack_set_name = aws_cloudformation_stack_set.lacework_stackset.name
+  depends_on = [ // depending on all this ensures the stackinstances can be torn down properly
+    aws_s3_bucket.lacework_org_lambda,
+    aws_sns_topic.lacework_sns_topic,
+    aws_sns_topic_subscription.lacework_sns_subscription,
+    aws_sns_topic_policy.default,
+    aws_lambda_permission.lacework_lambda_permission,
+    aws_secretsmanager_secret.lacework_api_credentials,
+    aws_lambda_function.lacework_setup_function
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -95,3 +95,27 @@ variable "kms_key_multi_region" {
   default     = true
   description = "Whether the KMS key is a multi-region or regional key"
 }
+
+variable "stackset_max_concurrent_count" {
+  type        = number
+  default     = 50
+  description = "The maximum number of AWS accounts to deploy to concurrently"
+}
+
+variable "stackset_failure_tolerance_count" {
+  type        = number
+  default     = 5
+  description = "The maxiumum number of failed AWS account integrations to tolerate"
+}
+
+variable "stackset_region_concurrency_type" {
+  type        = string
+  default     = "PARALLEL"
+  description = "Allow stackset instance deployment to run in parallel"
+}
+
+variable "stackset_managed_execution" {
+  type        = bool
+  default     = true
+  description = "Allow StackSets to perform non-conflicting operations concurrently and queues conflicting operations."
+}

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.11.0"
+      version = ">= 3.55.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.35.0"
+      version = ">= 5.11.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Large environments will take hours to deploy if we do not enable parallelization.

## How did you test this change?

Manual execution:

* creation
* updates
* deletion

Update/deletes tested 

## Issue

https://lacework.atlassian.net/browse/GROW-2583