### PR TITLE
chore: downgrade Python version to 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.55.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.35.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.55.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -44,9 +44,20 @@ resource "aws_lambda_function" "lacework_copy_zip_files" {
   function_name    = "lacework_copy_zip_files"
   handler          = "index.handler"
   role             = aws_iam_role.lacework_copy_zip_files_role.arn
-  runtime          = "python3.11"
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   timeout          = 240
+
+  # Python3.9 support introduced in version 3.55.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/release/3.x/CHANGELOG.md#3550-august-19-2021
+  runtime = "python3.9"
+
+  # Python3.10 support introduced in version 4.64.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/release/4.x/CHANGELOG.md#4640-april-20-2023
+  # runtime = "python3.10"
+
+  # Python3.11 support introduced in version 5.11.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5110-august--3-2023
+  # runtime = "python3.11"
 
   tracing_config {
     mode = "Active"
@@ -143,10 +154,21 @@ resource "aws_lambda_function" "lacework_setup_function" {
   function_name = "lacework_setup_function"
   handler       = "lw_integration_lambda_function.handler"
   role          = aws_iam_role.lacework_setup_function_role.arn
-  runtime       = "python3.11"
   s3_bucket     = aws_s3_bucket.lacework_org_lambda.bucket
   s3_key        = local.s3_lambda_key
   timeout       = 900
+
+  # Python3.9 support introduced in version 3.55.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/release/3.x/CHANGELOG.md#3550-august-19-2021
+  runtime = "python3.9"
+
+  # Python3.10 support introduced in version 4.64.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/release/4.x/CHANGELOG.md#4640-april-20-2023
+  # runtime = "python3.10"
+
+  # Python3.11 support introduced in version 5.11.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5110-august--3-2023
+  # runtime = "python3.11"
 
   tracing_config {
     mode = "Active"

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,16 @@
 locals {
+  # Python3.9 support introduced in version 3.55.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/release/3.x/CHANGELOG.md#3550-august-19-2021
+  python_version = "python3.9"
+
+  # Python3.10 support introduced in version 4.64.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/release/4.x/CHANGELOG.md#4640-april-20-2023
+  # python_version = "python3.10"
+
+  # Python3.11 support introduced in version 5.11.0
+  # https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5110-august--3-2023
+  # python_version = "python3.11"
+
   kms_key_arn   = length(var.kms_key_arn) > 0 ? var.kms_key_arn : aws_kms_key.lacework_kms_key[0].arn
   lambda_zip    = "LaceworkIntegrationSetup1.1.2.zip"
   s3_lambda_key = "${var.cf_s3_prefix}/lambda/${local.lambda_zip}"
@@ -46,18 +58,7 @@ resource "aws_lambda_function" "lacework_copy_zip_files" {
   role             = aws_iam_role.lacework_copy_zip_files_role.arn
   source_code_hash = data.archive_file.lambda_zip_file.output_base64sha256
   timeout          = 240
-
-  # Python3.9 support introduced in version 3.55.0
-  # https://github.com/hashicorp/terraform-provider-aws/blob/release/3.x/CHANGELOG.md#3550-august-19-2021
-  runtime = "python3.9"
-
-  # Python3.10 support introduced in version 4.64.0
-  # https://github.com/hashicorp/terraform-provider-aws/blob/release/4.x/CHANGELOG.md#4640-april-20-2023
-  # runtime = "python3.10"
-
-  # Python3.11 support introduced in version 5.11.0
-  # https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5110-august--3-2023
-  # runtime = "python3.11"
+  runtime          = local.python_version
 
   tracing_config {
     mode = "Active"
@@ -157,18 +158,7 @@ resource "aws_lambda_function" "lacework_setup_function" {
   s3_bucket     = aws_s3_bucket.lacework_org_lambda.bucket
   s3_key        = local.s3_lambda_key
   timeout       = 900
-
-  # Python3.9 support introduced in version 3.55.0
-  # https://github.com/hashicorp/terraform-provider-aws/blob/release/3.x/CHANGELOG.md#3550-august-19-2021
-  runtime = "python3.9"
-
-  # Python3.10 support introduced in version 4.64.0
-  # https://github.com/hashicorp/terraform-provider-aws/blob/release/4.x/CHANGELOG.md#4640-april-20-2023
-  # runtime = "python3.10"
-
-  # Python3.11 support introduced in version 5.11.0
-  # https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5110-august--3-2023
-  # runtime = "python3.11"
+  runtime       = local.python_version
 
   tracing_config {
     mode = "Active"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.35.0"
+      version = ">= 3.55.0"
     }
   }
 }


### PR DESCRIPTION

## Summary

Our Python scripts doesn't need to be on version `3.11`, we are downgrading them to `3.9`
so that we can support more versions of the AWS provider.

## How did you test this change?

Updated my stack and onboarded new accounts. Scripts run successfully on the old version.

<img width="1665" alt="Screenshot 2023-11-17 at 10 49 29 AM" src="https://github.com/lacework/terraform-aws-org-configuration/assets/5712253/fe05acd5-313c-4b41-abe2-f13d32ed58cc">

## Issue
N/A
