### PR TITLE
chore: use secret ARN instead of name for Lacework API credentials

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ locals {
   kms_key_arn   = length(var.kms_key_arn) > 0 ? var.kms_key_arn : aws_kms_key.lacework_kms_key[0].arn
   lambda_zip    = "LaceworkIntegrationSetup1.1.2.zip"
   s3_lambda_key = "${var.cf_s3_prefix}/lambda/${local.lambda_zip}"
+  template_url  = "https://s3.amazonaws.com/${var.cf_s3_bucket}/${var.cf_s3_prefix}/templates/1.0.0/lacework-aws-cfg-member.template.yml"
 }
 
 data "aws_caller_identity" "current" {}
@@ -336,7 +337,7 @@ resource "aws_cloudformation_stack" "lacework_stack" {
     ResourceNamePrefix = var.cf_resource_prefix
     SecretArn          = aws_secretsmanager_secret.lacework_api_credentials.id
   }
-  template_url       = "https://s3.amazonaws.com/${var.cf_s3_bucket}/${var.cf_s3_prefix}/templates/lacework-aws-cfg-member.template.yml"
+  template_url       = local.template_url
   timeout_in_minutes = 30
   depends_on = [ // depending on all this ensures the stackinstances can be torn down properly
     aws_s3_bucket.lacework_org_lambda,
@@ -376,7 +377,7 @@ resource "aws_cloudformation_stack_set" "lacework_stackset" {
   }
 
   permission_model = "SERVICE_MANAGED"
-  template_url     = "https://s3.amazonaws.com/${var.cf_s3_bucket}/${var.cf_s3_prefix}/templates/lacework-aws-cfg-member.template.yml"
+  template_url = local.template_url
   depends_on = [ // depending on all this ensures the stackinstances can be torn down properly
     aws_s3_bucket.lacework_org_lambda,
     aws_sns_topic.lacework_sns_topic,

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
   # python_version = "python3.11"
 
   kms_key_arn   = length(var.kms_key_arn) > 0 ? var.kms_key_arn : aws_kms_key.lacework_kms_key[0].arn
-  lambda_zip    = "LaceworkIntegrationSetup1.1.2.zip"
+  lambda_zip    = "LaceworkIntegrationSetup1.1.3.zip"
   s3_lambda_key = "${var.cf_s3_prefix}/lambda/${local.lambda_zip}"
   template_url  = "https://s3.amazonaws.com/${var.cf_s3_bucket}/${var.cf_s3_prefix}/templates/1.0.0/lacework-aws-cfg-member.template.yml"
 }

--- a/main.tf
+++ b/main.tf
@@ -228,7 +228,6 @@ resource "aws_lambda_permission" "lacework_lambda_permission" {
 resource "aws_secretsmanager_secret" "lacework_api_credentials" {
   description             = "Lacework API Access Keys"
   kms_key_id              = local.kms_key_arn
-  name                    = "LaceworkApiCredentials"
   recovery_window_in_days = 0
 }
 
@@ -335,6 +334,7 @@ resource "aws_cloudformation_stack" "lacework_stack" {
     LaceworkAccount    = var.lacework_account
     MainAccountSNS     = aws_sns_topic.lacework_sns_topic.arn
     ResourceNamePrefix = var.cf_resource_prefix
+    SecretArn          = aws_secretsmanager_secret.lacework_api_credentials.id
   }
   template_url       = "https://s3.amazonaws.com/${var.cf_s3_bucket}/${var.cf_s3_prefix}/templates/lacework-aws-cfg-member.template.yml"
   timeout_in_minutes = 30
@@ -359,7 +359,7 @@ resource "aws_cloudformation_stack_set" "lacework_stackset" {
   name         = var.cf_stack_name
 
   // GROW-2584: Workaround due to https://github.com/hashicorp/terraform-provider-aws/issues/23464
-  //            this block can be removed if there is a solution created for 23464 
+  //            this block can be removed if there is a solution created for 23464
   lifecycle {
     ignore_changes = [administration_role_arn]
   }
@@ -368,6 +368,7 @@ resource "aws_cloudformation_stack_set" "lacework_stackset" {
     LaceworkAccount    = var.lacework_account
     MainAccountSNS     = aws_sns_topic.lacework_sns_topic.arn
     ResourceNamePrefix = var.cf_resource_prefix
+    SecretArn          = aws_secretsmanager_secret.lacework_api_credentials.id
   }
 
   managed_execution {


### PR DESCRIPTION
## Summary

AWS will create unique ARN for each secret. Instead of name, we can use secret ARN to fetch the secret.

Depends on https://github.com/lacework-alliances/aws-org-cf-lacework/pull/7

## How did you test this change?

- Run `terraform apply` to test the terraform changes in this https://github.com/lacework/terraform-aws-org-configuration/pull/16.
- Verify resources are created in AWS and integrations are created in Lacework Platform.

## Issue

https://lacework.atlassian.net/browse/GROW-2579
