### PR TITLE
fix: increase cloudformation stack timeout

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -418,6 +418,12 @@ resource "aws_cloudformation_stack_set_instance" "lacework_stackset_instances" {
     region_concurrency_type = var.stackset_region_concurrency_type
   }
 
+  timeouts {
+    create = "1h"
+    update = "1h"
+    delete = "1h"
+  }
+
   region         = data.aws_region.current.name
   stack_set_name = aws_cloudformation_stack_set.lacework_stackset.name
   depends_on = [ // depending on all this ensures the stackinstances can be torn down properly


### PR DESCRIPTION
## Summary

Fix error when using the module to deploy cloudformation stacks in multiple AWS accounts

The default timeout  to deploy cloudformation stack is 30 minutes, in my environment this is enough time to deploy to approximately 30 AWS accounts, the problem is that my organization has more than 30 AWS accounts

## Issue

Error example:
```
╷
│ Error: creating CloudFormation StackSet (lacework-aws-org-configuration) Instance: waiting for completion: timeout while waiting for state to become 'SUCCEEDED' (last state: 'QUEUED', timeout: 30m0s)
│ 
│   with module.aws_org_configuration[0].aws_cloudformation_stack_set_instance.lacework_stackset_instances,
│   on .terraform/modules/aws_org_configuration/main.tf line 410, in resource "aws_cloudformation_stack_set_instance" "lacework_stackset_instances":
│  410: resource "aws_cloudformation_stack_set_instance" "lacework_stackset_instances" {
│ 
╵
```

Reference documentation:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance#timeouts
https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts
