### PR TITLE
fix: Fix the s3 template url by removing the version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
   kms_key_arn   = length(var.kms_key_arn) > 0 ? var.kms_key_arn : aws_kms_key.lacework_kms_key[0].arn
   lambda_zip    = "LaceworkIntegrationSetup1.1.3.zip"
   s3_lambda_key = "${var.cf_s3_prefix}/lambda/${local.lambda_zip}"
-  template_url  = "https://${var.cf_s3_bucket}.s3.${data.aws_region.current.name}.amazonaws.com/${var.cf_s3_prefix}/templates/1.0.0/lacework-aws-cfg-member.template.yml"
+  template_url  = "https://${var.cf_s3_bucket}.s3.us-west-2.amazonaws.com/${var.cf_s3_prefix}/templates/lacework-aws-cfg-member.template.yml"
   version_file   = "${abspath(path.module)}/VERSION"
   module_name    = "terraform-aws-org-configuration"
   module_version = fileexists(local.version_file) ? file(local.version_file) : ""  


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-org-configuration/blob/main/CONTRIBUTING.md
--->

## Summary

According to the [doc](https://github.com/lacework-alliances/aws-org-cf-lacework?tab=readme-ov-file#how-to-run), we don't have version number for the template url link. 

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->
