### PR TITLE
Fixing aws_iam_role deprecation warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,11 +100,13 @@ resource "aws_iam_role" "lacework_copy_zip_files_role" {
     policy = data.aws_iam_policy_document.lacework_copy_zip_files_role.json
   }
 
-  managed_policy_arns = [
-    "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-  ]
   name = "lacework_copy_zip_files_role"
   path = "/"
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "lacework_copy_zip_files_role" {
+  role_name   = aws_iam_role.lacework_copy_zip_files_role.name
+  policy_arns = ["arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
 }
 
 data "aws_iam_policy_document" "lacework_copy_zip_files_assume_role" {
@@ -193,11 +195,13 @@ resource "aws_iam_role" "lacework_setup_function_role" {
     policy = data.aws_iam_policy_document.lacework_setup_function_role.json
   }
 
-  managed_policy_arns = [
-    "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-  ]
   name = "lacework_setup_function_role"
   path = "/"
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "lacework_setup_function_role" {
+  role_name   = aws_iam_role.lacework_setup_function_role.name
+  policy_arns = ["arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
 }
 
 data "aws_partition" "current" {}


### PR DESCRIPTION
## Summary

Fixing deprecation warning.

```
╷
│ Warning: Argument is deprecated
│
│   with module.aws_org_configuration.aws_iam_role.lacework_copy_zip_files_role,
│   on .terraform/modules/aws_org_configuration/main.tf line 92, in resource "aws_iam_role" "lacework_copy_zip_files_role":
│   92:   managed_policy_arns = [
│   93:     "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
│   94:   ]
│
│ managed_policy_arns is deprecated. Use the aws_iam_role_policy_attachment resource instead. If Terraform should exclusively manage all managed policy attachments (the current behavior of this argument),
│ use the aws_iam_role_policy_attachments_exclusive resource as well.
```

## How did you test this change?
Tested locally using example
